### PR TITLE
Feature : rectangular networks

### DIFF
--- a/ccore/ccore/network.cpp
+++ b/ccore/ccore/network.cpp
@@ -29,10 +29,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdexcept>
 #include <algorithm>
 
+network::network(const unsigned int number_oscillators, 
+				 const conn_type connection_type,
+				 const unsigned int width_oscillators,
+				 const unsigned int height_oscillators) {
 
-network::network(const unsigned int number_oscillators, const conn_type connection_type) {
 	num_osc = number_oscillators;
 	m_conn_type = connection_type;
+	width_osc = width_oscillators;
+	height_osc = height_oscillators;
 
 	if ( (m_conn_type != conn_type::ALL_TO_ALL) && (m_conn_type != conn_type::NONE) ) {
 	    m_osc_conn.resize(number_oscillators, std::vector<unsigned int>());
@@ -198,22 +203,15 @@ void network::create_list_bidir_connections() {
 }
 
 void network::create_grid_four_connections() {
-	const double conv_side_size = std::sqrt((double) num_osc);
-	if (conv_side_size - std::floor(conv_side_size) > 0) {
-		throw std::runtime_error("Invalid number of oscillators in the network for the grid structure");
-	}
-
-	const unsigned int side_size = (unsigned int) conv_side_size;
 
 	for (unsigned int index = 0; index < num_osc; index++) {
 
-
-		const int upper_index = index - side_size;
-		const int lower_index = index + side_size;
+		const int upper_index = index - width_osc;
+		const int lower_index = index + width_osc;
 		const int left_index = index - 1;
 		const int right_index = index + 1;
 
-		unsigned int node_row_index = std::ceil(index / side_size);
+		unsigned int node_row_index = std::ceil(index / width_osc);
 		if (upper_index >= 0) {
 			set_connection(index, upper_index);
 		}
@@ -222,11 +220,11 @@ void network::create_grid_four_connections() {
 			set_connection(index, lower_index);
 		}
 
-		if ( (left_index >= 0) && (std::ceil(left_index / side_size) == node_row_index) ) {
+		if ( (left_index >= 0) && (std::ceil(left_index / width_osc) == node_row_index) ) {
 			set_connection(index, left_index);
 		}
 
-		if ( (right_index < num_osc) && (std::ceil(right_index / side_size) == node_row_index) ) {
+		if ( (right_index < num_osc) && (std::ceil(right_index / width_osc) == node_row_index) ) {
 			set_connection(index, right_index);
 		}
 	}
@@ -235,37 +233,35 @@ void network::create_grid_four_connections() {
 void network::create_grid_eight_connections() {
 	create_grid_four_connections();	/* create connection with right, upper, left, lower neighbor */
 	
-	const int side_size = (unsigned int) std::sqrt((double) num_osc);
-
 	for (unsigned int index = 0; index < num_osc; index++) {
-        const int upper_index = index - side_size;
-        const int upper_left_index = index - side_size - 1;
-        const int upper_right_index = index - side_size + 1;
+        const int upper_index = index - width_osc;
+        const int upper_left_index = index - width_osc - 1;
+        const int upper_right_index = index - width_osc + 1;
             
-        const int lower_index = index + side_size;
-        const int lower_left_index = index + side_size - 1;
-        const int lower_right_index = index + side_size + 1;
+        const int lower_index = index + width_osc;
+        const int lower_left_index = index + width_osc - 1;
+        const int lower_right_index = index + width_osc + 1;
             
         const int left_index = index - 1;
         const int right_index = index + 1;
             
-        const int node_row_index = std::floor(index / side_size);
+        const int node_row_index = std::floor(index / width_osc);
         const int upper_row_index = node_row_index - 1;
         const int lower_row_index = node_row_index + 1;
 
-		if ( (upper_left_index >= 0) && (std::floor(upper_left_index / side_size) == upper_row_index) ) {
+		if ( (upper_left_index >= 0) && (std::floor(upper_left_index / width_osc) == upper_row_index) ) {
 			set_connection(index, upper_left_index);
 		}
 
-		if ( (upper_right_index >= 0) && (std::floor(upper_right_index / side_size) == upper_row_index) ) {
+		if ( (upper_right_index >= 0) && (std::floor(upper_right_index / width_osc) == upper_row_index) ) {
 			set_connection(index, upper_right_index);
 		}
 
-		if ( (lower_left_index < num_osc) && (std::floor(lower_left_index / side_size) == lower_row_index) ) {
+		if ( (lower_left_index < num_osc) && (std::floor(lower_left_index / width_osc) == lower_row_index) ) {
 			set_connection(index, lower_left_index);
 		}
 
-		if ( (lower_right_index < num_osc) && (std::floor(lower_right_index / side_size) == lower_row_index) ) {
+		if ( (lower_right_index < num_osc) && (std::floor(lower_right_index / width_osc) == lower_row_index) ) {
 			set_connection(index, lower_right_index);
 		}
 	}

--- a/ccore/ccore/network.h
+++ b/ccore/ccore/network.h
@@ -118,13 +118,18 @@ private:
 class network {
 private:
 	unsigned int			num_osc;
+	unsigned int            width_osc;
+	unsigned int            height_osc; 
 	conn_repr_type			conn_representation;
 	conn_type				m_conn_type;
 
 	std::vector<std::vector<unsigned int> >		m_osc_conn;
 
 public:
-	network(const unsigned int number_oscillators, const conn_type connection_type);
+	network(const unsigned int number_oscillators, 
+		 	const conn_type connection_type,
+		 	const unsigned int width_oscillators,
+    	 	const unsigned int height_oscillators);
 
 	virtual ~network();
 

--- a/ccore/ccore/pcnn.cpp
+++ b/ccore/ccore/pcnn.cpp
@@ -1,11 +1,14 @@
 #include "pcnn.h"
-
 #include <unordered_set>
 
-pcnn::pcnn(const unsigned int size, const conn_type connection_type, const pcnn_parameters & parameters) :
+pcnn::pcnn(const unsigned int size, 
+		   const conn_type connection_type, 
+		   const pcnn_parameters & parameters,
+		   const unsigned int width_oscillators,
+		   const unsigned int height_oscillators) :
 	m_oscillators(size, pcnn_oscillator()), 
-	network(size, connection_type)
-{
+	network(size, connection_type, width_oscillators, height_oscillators){
+	
 	m_params = parameters;
 }
 

--- a/ccore/ccore/pcnn.h
+++ b/ccore/ccore/pcnn.h
@@ -93,7 +93,11 @@ private:
 	pcnn(void);
 
 public:
-	pcnn(const unsigned int num_osc, const conn_type connection_type, const pcnn_parameters & parameters);
+	pcnn(const unsigned int num_osc, 
+		 const conn_type connection_type, 
+		 const pcnn_parameters & parameters,
+		 const unsigned int width_osc,
+		 const unsigned int height_osc);
 
 	virtual ~pcnn(void);
 


### PR DESCRIPTION
This PR attempts to add support for rectangular images/networks, as mentioned in Issue https://github.com/annoviko/pyclustering/issues/259. I have made some changes in `ccore/network.cpp/h` and `ccore/pcnn.cpp/h` in two separate commits. 
Tagging @annoviko for review. Let me know what you think, before I proceed further. 

Criticisms:
- This is currently a breaking change, and will have to be propagated throughout the layers - changes in the python wrappers, libraries etc need to be added. 
Maybe the original constructor should be retained, which enforces perfect square no of oscillators? - (num_osc is now redundant, if one uses width*height. But have left it as it's used in other networks)
And this feature should be developed branch 
- Too many parameters in constructor. -> Define new struct?
- `height_oscillators` is not actually used. 
- Minor indentation problems due to editor :\ 

