### PR TITLE
Do not require pyclustering when installing pyclustering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ def full_setup():
           keywords = 'pyclustering data mining cluster analysis neural oscillatory networks',
           author = 'Andrei Novikov',
           author_email = 'pyclustering@yandex.ru',
-          install_requires = ['pyclustering'],
           packages = find_packages(),
           package_data = {
                             'pyclustering.samples': ['samples/*.txt', 'graphs/*.grpr', 'images/*.png', 'images/digits/*.png'],


### PR DESCRIPTION
Installing pyclustering using pip fails because pip tries to install pyclustering when installing pyclustering.
![yo_dawg1-622x253](https://cloud.githubusercontent.com/assets/6539261/15092357/af885212-1467-11e6-952f-e32aa9333e4c.jpg)
