### PR TITLE
This function does *not* compute the geometric median

### DIFF
--- a/pyclustering/utils/__init__.py
+++ b/pyclustering/utils/__init__.py
@@ -232,21 +232,21 @@ def average_neighbor_distance(points, num_neigh):
 
 def median(data, indexes = None, **kwargs):
     """!
-    @brief Calculate geometric median of input set of points using Euclidean distance.
+    @brief Calculate medoid of input set of points using Euclidean distance.
     
-    @param[in] data (list): Set of points for median calculation.
-    @param[in] indexes (list): Indexes of objects in input set of points that will be taken into account during median calculation.
+    @param[in] data (list): Set of points for medoid calculation.
+    @param[in] indexes (list): Indexes of objects in input set of points that will be taken into account during medoid calculation.
     @param[in] **kwargs: Arbitrary keyword arguments (available arguments: 'metric', 'data_type').
 
     <b>Keyword Args:</b><br>
         - metric (distance_metric): Metric that is used for distance calculation between two points.
         - data_type (string): Data type of input sample 'data' (available values: 'points', 'distance_matrix').
 
-    @return (uint) index of point in input set that corresponds to median.
+    @return (uint) index of point in input set that corresponds to medoid.
     
     """
     
-    index_median = None;
+    index_medoid = None;
     distance = float('Inf');
 
     metric = kwargs.get('metric', type_metric.EUCLIDEAN_SQUARE);
@@ -275,9 +275,9 @@ def median(data, indexes = None, **kwargs):
         
         if distance_candidate < distance:
             distance = distance_candidate;
-            index_median = index_candidate;
+            index_medoid = index_candidate;
     
-    return index_median;
+    return index_medoid;
 
 
 def euclidean_distance(a, b):


### PR DESCRIPTION
Instead, it computed the medoid, the sample with the smallest distance sum.

C.f.: https://en.wikipedia.org/wiki/Geometric_median

The geometric median is usually not restricted to sample points, but continuous in R^d. This is more complex, but allows for better solutions than just the sample points (as in k-means, but requires more computational effort).

The method should be renamed to avoid confusion with the common notion of "median", but as I am editing this in github, I don't have an easy backwards search or refactoring. Therefore, I only fix the documentation in this pull request. You may want to edit it to rename the method to "medoid" instead.