### PR TITLE
correct type error when using distance functions

### DIFF
--- a/pyclustering/utils/metric.py
+++ b/pyclustering/utils/metric.py
@@ -328,6 +328,7 @@ def euclidean_distance_numpy(object1, object2):
     @return (double) Euclidean distance between two objects.
 
     """
+    object2 = numpy.array(object2)
     if len(object1.shape) > 1 or len(object2.shape) > 1:
         return numpy.sqrt(numpy.sum(numpy.square(object1 - object2), axis=1))
     else:
@@ -367,6 +368,7 @@ def euclidean_distance_square_numpy(object1, object2):
     @return (double) Square Euclidean distance between two objects.
 
     """
+    object2 = numpy.array(object2)
     if len(object1.shape) > 1 or len(object2.shape) > 1:
         return numpy.sum(numpy.square(object1 - object2), axis=1).T
     else:
@@ -408,6 +410,7 @@ def manhattan_distance_numpy(object1, object2):
     @return (double) Manhattan distance between two objects.
 
     """
+    object2 = numpy.array(object2)
     if len(object1.shape) > 1 or len(object2.shape) > 1:
         return numpy.sum(numpy.absolute(object1 - object2), axis=1).T
     else:
@@ -451,6 +454,7 @@ def chebyshev_distance_numpy(object1, object2):
     @return (double) Chebyshev distance between two objects.
 
     """
+    object2 = numpy.array(object2)
     if len(object1.shape) > 1 or len(object2.shape) > 1:
         return numpy.max(numpy.absolute(object1 - object2), axis=1).T
     else:
@@ -492,6 +496,7 @@ def minkowski_distance_numpy(object1, object2, degree=2):
     @return (double) Minkowski distance between two object.
 
     """
+    object2 = numpy.array(object2)
     if len(object1.shape) > 1 or len(object2.shape) > 1:
         return numpy.power(numpy.sum(numpy.power(object1 - object2, degree), axis=1), 1/degree)
     else:


### PR DESCRIPTION
As mentioned in issue #671, a type error is raised when using certain distance functions with numpy. Seems like it's just an issue of a list not being converted to a numpy array at some point in the process. I'm not sure if my corrections fix the problem in all instances of the code but it certainly corrects the issue for using Python and `kmeans`. There may be a better place to make the change but I couldn't get any other place to work. I also don't know any C++ so I didn't edit any of those (in case they need to be). Let me know if something is off :).