### PR TITLE
xmeans does not agree to paper?

### DIFF
--- a/pyclustering/cluster/xmeans.py
+++ b/pyclustering/cluster/xmeans.py
@@ -602,26 +602,26 @@ class xmeans:
         dimension = len(self.__pointer_data[0])
           
         # estimation of the noise variance in the data set
-        sigma_sqrt = 0.0
+        sigma_sq = 0.0
         K = len(clusters)
         N = 0.0
           
         for index_cluster in range(0, len(clusters), 1):
             for index_object in clusters[index_cluster]:
-                sigma_sqrt += self.__metric(self.__pointer_data[index_object], centers[index_cluster])
+                sigma_sq += self.__metric(self.__pointer_data[index_object], centers[index_cluster])
 
             N += len(clusters[index_cluster])
       
         if N - K > 0:
-            sigma_sqrt /= (N - K)
+            sigma_sq /= (N - K)
             p = (K - 1) + dimension * K + 1
 
             # in case of the same points, sigma_sqrt can be zero (issue: #407)
             sigma_multiplier = 0.0
-            if sigma_sqrt <= 0.0:
+            if sigma_sq <= 0.0:
                 sigma_multiplier = float('-inf')
             else:
-                sigma_multiplier = dimension * 0.5 * log(sigma_sqrt)
+                sigma_multiplier = dimension * 0.5 * log(sigma_sq)
             
             # splitting criterion    
             for index_cluster in range(0, len(clusters), 1):
@@ -629,10 +629,10 @@ class xmeans:
 
                 L = n * log(n) - n * log(N) - n * 0.5 * log(2.0 * numpy.pi) - n * sigma_multiplier - (n - K) * 0.5
                 
-                # BIC calculation
-                scores[index_cluster] = L - p * 0.5 * log(N)
+                scores[index_cluster] = L
                 
-        return sum(scores)
+        # BIC calculation
+        return sum(scores) - p * 0.5 * log(N)
 
 
     def __verify_arguments(self):


### PR DESCRIPTION
The last term, `p * 0.5 * log(N)`, should be in the sum only once IMHO. It is in the top BIC equation (j is the model index, not the cluster index), not in the l(Dn) equation where n is the cluster index) in https://web.cs.dal.ca/~shepherd/courses/csci6403/clustering/xmeans.pdf No guarantees that everything else is fine.

I also rename `sigma_sqrt` to `sigma_sq` because it is supposed to be sigma square, not square root.

Note that if `sigma_multiplier = float('-inf')`, the result will always be infinity, won't it?