### PR TITLE
change numpy.complex -> numpy.complex128 bc of depreciation

### DIFF
--- a/pyclustering/nnet/fsync.py
+++ b/pyclustering/nnet/fsync.py
@@ -335,7 +335,7 @@ class fsync_network(network):
         
         """
         
-        z = amplitude.view(numpy.complex);
+        z = amplitude.view(numpy.complex128);
         dzdt = self.__landau_stuart(z, argv) + self.__synchronization_mechanism(z, argv);
         
         return dzdt.view(numpy.float64);


### PR DESCRIPTION
Fix for #700.

I ran `python -m unittest pyclustering/nnet/tests/unit/ut_fsync.py` which failed before the fix and passed afterwards.

It turned out to be a very simple problem which is great ✨ Looking forward to using this simulator.