### PR TITLE
Partially added support for ARM64 compilation 

### DIFF
--- a/ccore/ccore.mk
+++ b/ccore/ccore.mk
@@ -40,20 +40,57 @@ endif
 
 
 # Target flag depending on platform
-ifeq ($(PLATFORM), 32-bit)
-	CFLAG_PLATFORM = -m32
-	LFLAG_PLATFORM = -m32
-else 
-	ifeq ($(PLATFORM), 64-bit)
-		CFLAG_PLATFORM = -m64
-		LFLAG_PLATFORM = -m64
+ifeq ($(OSNAME), macos)
+
+#   Arm case of MacOs
+	ifeq ($(shell uname -m), arm64)
+		CFLAG_PLATFORM = -march=native
+		LFLAG_PLATFORM = -march=native
+	else
+		ifeq ($(PLATFORM), 32-bit)
+			CFLAG_PLATFORM = -m32
+			LFLAG_PLATFORM = -m32
+		else 
+			ifeq ($(PLATFORM), 64-bit)
+				CFLAG_PLATFORM = -m64
+				LFLAG_PLATFORM = -m64
+			else
+				PLATFORM = 64-bit
+				CFLAG_PLATFORM = -m64
+				LFLAG_PLATFORM = -m64
+			endif
+		endif
+	endif
+else
+	ifeq ($(OSNAME), linux)
+#   Arm case of MacOs
+		ifeq ($(shell uname --m), aarch64)
+			CFLAG_PLATFORM = -march=native
+			LFLAG_PLATFORM = -march=native
+		else
+			ifeq ($(PLATFORM), 32-bit)
+				CFLAG_PLATFORM = -m32
+				LFLAG_PLATFORM = -m32
+			else 
+				ifeq ($(PLATFORM), 64-bit)
+					CFLAG_PLATFORM = -m64
+					LFLAG_PLATFORM = -m64
+				else
+					PLATFORM = 64-bit
+					CFLAG_PLATFORM = -m64
+					LFLAG_PLATFORM = -m64
+				endif
+			endif
+		endif
+
 	else
 		PLATFORM = 64-bit
 		CFLAG_PLATFORM = -m64
 		LFLAG_PLATFORM = -m64
+	
 	endif
-endif
 
+endif
 
 # Definitions
 DEFINITION_FLAGS =

--- a/ccore/include/pyclustering/utils/metric.hpp
+++ b/ccore/include/pyclustering/utils/metric.hpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <limits>
 
 
 namespace pyclustering {


### PR DESCRIPTION
Hi!

I did this small PR to partly add support for compilation under `arm64`,  I tested on a Linux machine with `arm64` architecture and it works! 
Some test fails due to precision being to high but overall it's working. 

I modified as well the file `ccore/include/pyclustering/utils/metric.hpp` adding `#include <limits>` this should also fix the latest [GitHubAction](https://github.com/annoviko/pyclustering/actions/runs/7833147744/job/21373499176) failure.

This PR fixes the installation for ARM only with the Build Manually. 

Having also the already build package for arm, it involves a big refactor on the whole ci/cd.

If you want I could help you with that. 🚀 